### PR TITLE
Rusi transport emit subscription errors

### DIFF
--- a/.changeset/rude-needles-taste.md
+++ b/.changeset/rude-needles-taste.md
@@ -1,0 +1,5 @@
+---
+'@totalsoft/message-bus': patch
+---
+
+Msgbus Rusi transport emit subscription error

--- a/packages/message-bus/__tests__/transport/rusi.test.ts
+++ b/packages/message-bus/__tests__/transport/rusi.test.ts
@@ -229,6 +229,23 @@ describe('Testing rusi transport', () => {
     expect(errorListener).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringContaining('subject') }))
   })
 
+  test('subscription does not throw when call emits error or end without error listeners', async () => {
+    // arrange
+    const { EventEmitter } = require('events')
+    const realCall = Object.assign(new EventEmitter(), { cancel: jest.fn(), write: jest.fn() })
+    mockRusiClient.Subscribe.mockReturnValueOnce(realCall)
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    await rusi.subscribe('subject', jest.fn(), SubscriptionOptions.PUB_SUB, serDes)
+
+    // act - assert
+    expect(() => realCall.emit('error', new Error('sidecar subscription error'))).not.toThrow()
+    expect(() => realCall.emit('end')).not.toThrow()
+    expect(errorSpy).toHaveBeenCalled()
+
+    errorSpy.mockRestore()
+  })
+
   test('disconnect happens if the connection is open', async () => {
     // arrange
 

--- a/packages/message-bus/__tests__/transport/rusi.test.ts
+++ b/packages/message-bus/__tests__/transport/rusi.test.ts
@@ -41,7 +41,8 @@ describe('Testing rusi transport', () => {
         cancel: jest.fn(),
         end: jest.fn(),
         write: jest.fn(),
-        on: jest.fn()
+        on: jest.fn(),
+        removeListener: jest.fn()
       })),
       close: jest.fn()
     }
@@ -166,6 +167,66 @@ describe('Testing rusi transport', () => {
 
     // assert
     expect(sub._call?.cancel).toBeCalled()
+  })
+
+  test('subscribe registers error and end listeners on call', async () => {
+    // arrange
+    const subject = 'subject'
+
+    // act
+    const sub = <RusiSubscription>await rusi.subscribe(subject, jest.fn(), SubscriptionOptions.PUB_SUB, serDes)
+
+    // assert
+    expect(sub._call?.on).toHaveBeenCalledWith('error', expect.any(Function))
+    expect(sub._call?.on).toHaveBeenCalledWith('end', expect.any(Function))
+  })
+
+  test('unsubscribe removes error and end listeners before cancelling', async () => {
+    // arrange
+    const sub = <RusiSubscription>await rusi.subscribe('subject', jest.fn(), SubscriptionOptions.STREAM_PROCESSOR, serDes)
+
+    // act
+    await sub.unsubscribe?.call(sub)
+
+    // assert
+    expect(sub._call?.removeListener).toHaveBeenCalledWith('error', expect.any(Function))
+    expect(sub._call?.removeListener).toHaveBeenCalledWith('end', expect.any(Function))
+    expect(sub._call?.cancel).toBeCalled()
+  })
+
+  test('subscription emits error when call emits error', async () => {
+    // arrange — use a real EventEmitter for call so events propagate
+    const { EventEmitter } = require('events')
+    const realCall = Object.assign(new EventEmitter(), { cancel: jest.fn(), write: jest.fn() })
+    mockRusiClient.Subscribe.mockReturnValueOnce(realCall)
+
+    const sub = await rusi.subscribe('subject', jest.fn(), SubscriptionOptions.PUB_SUB, serDes)
+    const errorListener = jest.fn()
+    sub.on('error', errorListener)
+
+    // act
+    const testError = new Error('sidecar subscription error')
+    realCall.emit('error', testError)
+
+    // assert
+    expect(errorListener).toHaveBeenCalledWith(testError)
+  })
+
+  test('subscription emits error when call emits end', async () => {
+    // arrange
+    const { EventEmitter } = require('events')
+    const realCall = Object.assign(new EventEmitter(), { cancel: jest.fn(), write: jest.fn() })
+    mockRusiClient.Subscribe.mockReturnValueOnce(realCall)
+
+    const sub = await rusi.subscribe('subject', jest.fn(), SubscriptionOptions.PUB_SUB, serDes)
+    const errorListener = jest.fn()
+    sub.on('error', errorListener)
+
+    // act
+    realCall.emit('end')
+
+    // assert
+    expect(errorListener).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringContaining('subject') }))
   })
 
   test('disconnect happens if the connection is open', async () => {

--- a/packages/message-bus/src/transport/rusi/index.ts
+++ b/packages/message-bus/src/transport/rusi/index.ts
@@ -170,16 +170,7 @@ export async function subscribe(
     const ackRequest = { message_id: msg.id /* , error: null*/ }
     call.write?.call(call, { ack_request: ackRequest })
   })
-  call.on('end', function () {
-    // The server has finished sending
-    console.error(`Rusi subscription ended for subject ${subject}.`)
-  })
-  call.on('error', function (e) {
-    // An error has occurred and the stream has been closed.
-    console.error(`Rusi subscription error for subject ${subject}: ${e}`)
-  })
-
-  const sub = rusiSubscription(call)
+  const sub = rusiSubscription(call, subject)
   return sub
 }
 
@@ -241,16 +232,25 @@ function fromUTF8Array(data: number[]): string {
   return str
 }
 
-function rusiSubscription(call: grpc.ClientDuplexStream<any, any>): RusiSubscription {
+function rusiSubscription(call: grpc.ClientDuplexStream<any, any>, subject?: string): RusiSubscription {
   const sub = <RusiSubscription> new EventEmitter()
-  sub.on('removeListener', (event, listener) => {
-    call.removeListener(event, listener)
-  })
-  sub.on('newListener', (event, listener) => {
-    call.on(event, listener)
-  })
+
+  const onError = function (e: Error) {
+    console.error(`Rusi subscription error for subject ${subject}: ${e}`)
+    sub.emit('error', e)
+  }
+  const onEnd = function () {
+    const err = new Error(`Rusi subscription ended for subject ${subject}.`)
+    console.error(err.message)
+    sub.emit('error', err)
+  }
+
+  call.on('error', onError)
+  call.on('end', onEnd)
 
   sub.unsubscribe = function unsubscribe() {
+    call.removeListener('error', onError)
+    call.removeListener('end', onEnd)
     call.cancel?.call(call)
     return Promise.resolve()
   }

--- a/packages/message-bus/src/transport/rusi/index.ts
+++ b/packages/message-bus/src/transport/rusi/index.ts
@@ -235,14 +235,20 @@ function fromUTF8Array(data: number[]): string {
 function rusiSubscription(call: grpc.ClientDuplexStream<any, any>, subject?: string): RusiSubscription {
   const sub = <RusiSubscription> new EventEmitter()
 
+  const emitError = function (error: Error) {
+    if (sub.listenerCount('error') > 0) {
+      sub.emit('error', error)
+    }
+  }
+
   const onError = function (e: Error) {
     console.error(`Rusi subscription error for subject ${subject}: ${e}`)
-    sub.emit('error', e)
+    emitError(e)
   }
   const onEnd = function () {
     const err = new Error(`Rusi subscription ended for subject ${subject}.`)
     console.error(err.message)
-    sub.emit('error', err)
+    emitError(err)
   }
 
   call.on('error', onError)


### PR DESCRIPTION
## Problem

When the rusi sidecar returns subscription-level stream errors (e.g. `stan: subscribe request timeout`), the gRPC channel remains `READY` so no connection-level error fires. The rusi transport only logged these errors and never forwarded them to the `Subscription` EventEmitter, causing subscribers to silently hang with no possibility of recovery.

## Solution

Rewrite `rusiSubscription` to forward `call` stream errors and end events onto the subscription's EventEmitter, so callers (e.g. `messaging-host`) can react to subscription-level failures.

### Changes

**`rusiSubscription(call, subject)`**
- Added named `onError` handler: logs the error and calls `sub.emit('error', e)`
- Added named `onEnd` handler: synthesises an `Error` and calls `sub.emit('error', err)` — a stream ending unexpectedly is treated as an error
- `unsubscribe()` removes both listeners via `removeListener` before calling `call.cancel()`, preventing spurious error events on intentional shutdown (same outcome as .NET's `catch when StatusCode == Cancelled` filter, without needing to inspect the error type)
- `subject` parameter added and threaded through from `subscribe()` for use in log messages

**Tests: 4 new cases**
- `subscribe registers error and end listeners on call`
- `unsubscribe removes error and end listeners before cancelling`
- `subscription emits error when call emits error`
- `subscription emits error when call emits end`